### PR TITLE
swap history analysis to default and restart analysis to optional

### DIFF
--- a/acre_driver.py
+++ b/acre_driver.py
@@ -22,12 +22,21 @@
 #     - h1,h2,h3 files
 #     - add more checks
 #     - optimize math and averaging
+#
+#
+#  FYI: REALLY HELPFULL DEBUG TOOL
+#  UNcomment the imported "code" library and add the following call
+#  in the code where you want to add a debug stop:
+#        code.interact(local=locals())
+#
+#
+#
 # =======================================================================================
 
 import matplotlib.pyplot as plt
 import sys
 import getopt
-import code  # For development: code.interact(local=locals())
+#import code  # For development: code.interact(local=locals())
 import time
 import acre_history_utils as hutils
 import acre_restart_utils as rutils
@@ -490,6 +499,7 @@ def main(argv):
         test_restart_list = getnclist(test_r_prefix,'restart')
         ## number of test-case restart files
         n_r_files = test_restart_list.__len__()
+        n_rtypes  = 1
         if(n_r_files <= 0):
             print('acre could not find any restart files, and you optioned for restart analysis')
             sys.exit(2)
@@ -604,7 +614,6 @@ def main(argv):
         # found in the acre_history_utils module (hutils)
 
         if(restartmode):
-        
             # Initialize (or re-initialize) the rvars class
             rvar = rutils.rvars(n_rtypes,n_r_files,test_name,base_name)
     
@@ -626,7 +635,12 @@ def main(argv):
 
             putils.multipanel_histplot(site,hvarlist,"MMV",n_htypes)
             putils.multipanel_histplot(site,hvarlist,"DMV",n_htypes)
-            putils.multipanel_histplot(site,hvarlist,"AMV",n_htypes)
+
+            if(hdims.nyears>1):
+                putils.multipanel_histplot(site,hvarlist,"AMV",n_htypes)
+            else:
+                print('Omitting plots of annual trends')
+                print('Less than two years of data provided')
 
             if(restartmode):
                 ## Make some restart analysis plots

--- a/acre_history_utils.py
+++ b/acre_history_utils.py
@@ -2,7 +2,7 @@
 ## @package acre_history_utils a bunch of scripts that help interperate
 
 
-import code
+#import code   # For development: code.interact(local=locals())
 import numpy as np
 import xml.etree.ElementTree as et
 from scipy.io import netcdf
@@ -181,7 +181,6 @@ class hist_vars:
         if(self.dimclass is None):
             print('History Variable: '+name+' does not have a registered dimensionality')
             print('in this toolset.  ')
-            code.interact(local=locals())
             exit(0)
 
         # Determine what types of output formats are requested
@@ -365,7 +364,7 @@ def load_history(file,igh,hvarlist,htype,scr,hdims):
         if(hvar.dimclass=='3dlndscpf'):
             rawshape = fp.variables[hvar.name].shape
             scpf_dim = 1   # 0 is time, and 2 is space
-#            code.interact(local=locals())
+
             # ----------------------------------------------------------------
             # In some cases we want to just condense the second dimension
             # the "scpf" dimension into a single value.

--- a/acre_plot_utils.py
+++ b/acre_plot_utils.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import code  # For development: code.interact(local=locals())
+#import code  # For development: code.interact(local=locals())
 import sys
 import matplotlib.dates as mdates
 
@@ -286,7 +286,6 @@ def multipanel_histplot(site,hvarlist,atype,n_htypes):
         if(acheck):
             
             count += 1
-#            code.interact(local=locals())
             if(count>4):
 
                 figh = plt.figure(figsize=[9,8])


### PR DESCRIPTION
The existing implementation of this tool implemented an analysis on the restart files as the only non-optional analysis.  The analysis was on dedicated FATES vegetation composition restart variables.

In order to make this tool work on non-fates simulations, the analysis has to default to output formats that are agnostic of fates non-fates.  So I swapped the default analysis to be on history variables.  Since the desired variables in the history analysis are controlled by the user, non-fates (CLM/ALM) users will be able to run the tool.